### PR TITLE
FEA: Add better outputs to suggested strand version

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ You can also:
 | `show_gql_logs`  | Boolean |          | `false`  | Show logs from the `gql` library (these can help with troubleshooting but are quite verbose)                                                                                                                                                                                             |
 
 ### Outputs
-| Name                  | Type   | Description                            |
-|-----------------------|--------|----------------------------------------|
-| `strand_url`          | String | The URL for the strand                 |
-| `strand_version_url`  | String | The URL for the new strand version     |
-| `strand_version_uuid` | String | The UUID of the new strand version     |
-| `version`             | String | The semantic version used or suggested |
+| Name                  | Type   | Description                                                                              |
+|-----------------------|--------|------------------------------------------------------------------------------------------|
+| `strand_url`          | String | The URL for the strand                                                                   |
+| `strand_version_url`  | String | The URL for the new strand version                                                       |
+| `strand_version_uuid` | String | The UUID of the new strand version                                                       |
+| `version`             | String | The semantic version used or suggested                                                   |
+| `change`              | String | The type of change detected (`equal`, `initial`, `patch`, `minor`, or `major`)           |
+| `latest_version`      | String | The highest published version of the strand (including candidate releases), or empty      |
+| `stable_version`      | String | The highest published non-candidate version, or empty                                    |
 
 
 ## Examples

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,12 @@ outputs:
     description: 'The UUID of the new strand version.'
   version:
     description: 'The semantic version used or suggested'
+  change:
+    description: 'The type of change detected (equal, initial, patch, minor, or major)'
+  latest_version:
+    description: 'The highest published version of the strand (including candidate releases), or empty if none exists'
+  stable_version:
+    description: 'The highest published non-candidate version, or empty if none exists'
 
 runs:
    using: 'docker'

--- a/publish_strand_version/api.py
+++ b/publish_strand_version/api.py
@@ -37,30 +37,32 @@ def publish_strand_version(
     :param str notes: any notes to associate with the strand version
     :param bool allow_beta: if `False` and the base version is a beta version (< 1.0.0), interpret major/breaking changes as increasing the version to the lowest non-beta version (1.0.0)
     :param bool suggest_only: if `True`, just return the suggested new version
-    :return (str|None, str|None, str|None, str, bool): the strand URL, strand version URL, strand version UUID, semantic version, and whether the strand version was published
+    :return (str|None, str|None, str|None, str, bool, str, str, str): the strand URL, strand version URL, strand version UUID, semantic version, whether the strand version was published, change type, latest version, and stable version
     """
     if suggest_only and version:
         raise ValueError("The `version` argument cannot be set while `suggest_only=True`.")
 
     suid = f"{account}/{name}"
 
+    suggested_version, changed, change, latest_version, stable_version = _suggest_sem_ver(
+        token=token,
+        base=suid,
+        proposed=json.dumps(json_schema),
+        allow_beta=allow_beta,
+    )
+
     if version:
-        logger.info("Semantic version manually specified - skipping version suggestion.")
+        logger.info("Semantic version manually specified - using provided version.")
     else:
-        version, changed = _suggest_sem_ver(
-            token=token,
-            base=suid,
-            proposed=json.dumps(json_schema),
-            allow_beta=allow_beta,
-        )
+        version = suggested_version
 
         if not changed:
             logger.info("Schema hasn't changed - skipping publishing.")
-            return (None, None, None, version, False)
+            return (None, None, None, version, False, change, latest_version, stable_version)
 
         if suggest_only:
             logger.info("Suggest-only mode enabled - skipping publishing.")
-            return (None, None, None, version, False)
+            return (None, None, None, version, False, change, latest_version, stable_version)
 
     strand_version_uuid = _create_strand_version(
         token=token,
@@ -73,7 +75,7 @@ def publish_strand_version(
 
     strand_url = "/".join((STRANDS_FRONTEND_URL, suid))
     strand_version_url = "/".join((STRANDS_SCHEMA_REGISTRY_URL, suid, f"{version}.json"))
-    return (strand_url, strand_version_url, strand_version_uuid, version, True)
+    return (strand_url, strand_version_url, strand_version_uuid, version, True, change, latest_version, stable_version)
 
 
 def _suggest_sem_ver(token, base, proposed, allow_beta):
@@ -84,7 +86,7 @@ def _suggest_sem_ver(token, base, proposed, allow_beta):
     :param str proposed: the proposed schema as a JSON-encoded string
     :param bool allow_beta: if `False` and the base version is a beta version (< 1.0.0), interpret major/breaking changes as increasing the version to the lowest non-beta version (1.0.0)
     :raises publish_strand_version.exceptions.StrandsException: if the query fails for any reason
-    :return (str, bool): the suggested semantic version for the proposed schema, and whether the schema has changed
+    :return (str, bool, str, str, str): the suggested semantic version, whether the schema has changed, the change type, the latest version, and the stable version
     """
     parameters = {"token": token, "base": base, "proposed": proposed, "allowBeta": allow_beta}
 
@@ -99,7 +101,9 @@ def _suggest_sem_ver(token, base, proposed, allow_beta):
             suggestSemVerViaToken(token: $token, base: $base, proposed: $proposed, allowBeta: $allowBeta) {
                 ... on VersionSuggestion {
                     suggestedVersion
-                    changeType
+                    change
+                    latestVersion
+                    stableVersion
                 }
                 ... on VersionSuggestionError {
                     type
@@ -124,17 +128,17 @@ def _suggest_sem_ver(token, base, proposed, allow_beta):
     if "messages" in response or "message" in response:
         raise StrandsException(response.get("messages") or response.get("message"))
 
-    if response["changeType"] == "equal":
-        message = "The schema hasn't changed. The suggested version is %s."
-        message_args = [response["suggestedVersion"]]
-        changed = False
-    else:
-        message = "The suggested semantic version is %s. This represents a %s change."
-        message_args = [response["suggestedVersion"], response["changeType"]]
-        changed = True
+    change = response["change"].lower()
+    changed = change != "equal"
+    latest_version = response["latestVersion"] or ""
+    stable_version = response["stableVersion"] or ""
 
-    logger.info(message, *message_args)
-    return response["suggestedVersion"], changed
+    if not changed:
+        logger.info("The schema hasn't changed. The suggested version is %s.", response["suggestedVersion"])
+    else:
+        logger.info("The suggested semantic version is %s. This represents a %s change.", response["suggestedVersion"], change)
+
+    return response["suggestedVersion"], changed, change, latest_version, stable_version
 
 
 def _create_strand_version(token, account, name, json_schema, version, notes=None):

--- a/publish_strand_version/cli.py
+++ b/publish_strand_version/cli.py
@@ -70,7 +70,7 @@ def main(argv=None):
         json_schema = json.load(f)
 
     try:
-        strand_url, strand_version_url, strand_version_uuid, version, published = publish_strand_version(
+        strand_url, strand_version_url, strand_version_uuid, version, published, change, latest_version, stable_version = publish_strand_version(
             token=args.token,
             account=args.account,
             name=args.name,
@@ -94,6 +94,9 @@ def main(argv=None):
                 f"strand_url={strand_url}\n",
                 f"strand_version_url={strand_version_url}\n",
                 f"strand_version_uuid={strand_version_uuid}\n",
+                f"change={change}\n",
+                f"latest_version={latest_version}\n",
+                f"stable_version={stable_version}\n",
             ]
         )
 
@@ -105,6 +108,9 @@ def main(argv=None):
     print(
         f"{GREEN}STRAND VERSION {mode} {status}{NO_COLOUR}\n"
         f"- Semantic version: {version}\n"
+        f"- Change: {change}\n"
+        f"- Latest version: {latest_version}\n"
+        f"- Stable version: {stable_version}\n"
         f"- Strand URL: {strand_url}\n"
         f"- Strand version URL: {strand_version_url}\n"
         f"- Strand version UUID: {strand_version_uuid}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "publish-strand-version"
-version = "0.3.2"
+version = "0.4.0"
 description = "A GitHub action that publishes JSON schemas to the Octue Strands app."
-authors = ["Marcus Lugg <marcus@octue.com>"]
+authors = ["Marcus Lugg <marcus@octue.com>", "Tom Clark <tom@octue.com>"]
 readme = "README.md"
 packages = [{include = "publish_strand_version"}]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,11 +26,11 @@ class TestPublishStrandVersion(unittest.TestCase):
 
     def test_suggest_only_mode(self):
         """Test that the strand version creation mutation is not used when suggest-only mode is enabled."""
-        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "changeType": "minor"}}
+        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "change": "MINOR", "latestVersion": "0.1.0", "stableVersion": "0.1.0"}}
 
         with patch("publish_strand_version.api._create_strand_version") as mock_create_strand_version:
             with patch("gql.Client.execute", return_value=mock_response):
-                strand_url, strand_version_url, strand_version_uuid, version, published = publish_strand_version(
+                strand_url, strand_version_url, strand_version_uuid, version, published, change, latest_version, stable_version = publish_strand_version(
                     token="some-token",
                     account="some",
                     name="strand",
@@ -44,6 +44,9 @@ class TestPublishStrandVersion(unittest.TestCase):
         self.assertIsNone(strand_version_url)
         self.assertIsNone(strand_version_uuid)
         self.assertFalse(published)
+        self.assertEqual(change, "minor")
+        self.assertEqual(latest_version, "0.1.0")
+        self.assertEqual(stable_version, "0.1.0")
 
     def test_publish_mode(self):
         """Test publishing a strand version."""
@@ -51,9 +54,12 @@ class TestPublishStrandVersion(unittest.TestCase):
 
         with patch(
             "gql.Client.execute",
-            side_effect=[{"createStrandVersionViaToken": {"uuid": expected_strand_version_uuid}}],
+            side_effect=[
+                {"suggestSemVerViaToken": {"suggestedVersion": "1.0.0", "change": "MAJOR", "latestVersion": "0.2.0", "stableVersion": "0.2.0"}},
+                {"createStrandVersionViaToken": {"uuid": expected_strand_version_uuid}},
+            ],
         ):
-            strand_url, strand_version_url, strand_version_uuid, version, published = publish_strand_version(
+            strand_url, strand_version_url, strand_version_uuid, version, published, change, latest_version, stable_version = publish_strand_version(
                 token="some-token",
                 account="some",
                 name="strand",
@@ -66,14 +72,17 @@ class TestPublishStrandVersion(unittest.TestCase):
         self.assertEqual(strand_version_uuid, expected_strand_version_uuid)
         self.assertEqual(version, "1.0.0")
         self.assertTrue(published)
+        self.assertEqual(change, "major")
+        self.assertEqual(latest_version, "0.2.0")
+        self.assertEqual(stable_version, "0.2.0")
 
     def test_publishing_skipped_if_schema_not_changed(self):
         """Test that publishing is skipped if the schema hasn't changed."""
-        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "changeType": "equal"}}
+        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "change": "EQUAL", "latestVersion": "0.2.0", "stableVersion": "0.2.0"}}
 
         with patch("publish_strand_version.api._create_strand_version") as mock_create_strand_version:
             with patch("gql.Client.execute", return_value=mock_response):
-                strand_url, strand_version_url, strand_version_uuid, version, published = publish_strand_version(
+                strand_url, strand_version_url, strand_version_uuid, version, published, change, latest_version, stable_version = publish_strand_version(
                     token="some-token",
                     account="some",
                     name="strand",
@@ -86,6 +95,9 @@ class TestPublishStrandVersion(unittest.TestCase):
         self.assertIsNone(strand_version_url)
         self.assertIsNone(strand_version_uuid)
         self.assertFalse(published)
+        self.assertEqual(change, "equal")
+        self.assertEqual(latest_version, "0.2.0")
+        self.assertEqual(stable_version, "0.2.0")
 
 
 class TestSuggestSemVer(unittest.TestCase):
@@ -106,7 +118,7 @@ class TestSuggestSemVer(unittest.TestCase):
         self.assertEqual(error_context.exception.args[0][0]["message"], "User is not authenticated.")
 
     def test_suggesting_sem_ver(self):
-        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "changeType": "minor"}}
+        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.2.0", "change": "MINOR", "latestVersion": "0.1.0", "stableVersion": "0.1.0"}}
         json_schema_encoded = json.dumps({"some": "schema"})
 
         with patch("gql.Client.execute", return_value=mock_response) as mock_execute:
@@ -117,12 +129,27 @@ class TestSuggestSemVer(unittest.TestCase):
                 allow_beta=True,
             )
 
-        self.assertEqual(response, ("0.2.0", True))
+        self.assertEqual(response, ("0.2.0", True, "minor", "0.1.0", "0.1.0"))
 
         self.assertEqual(
             mock_execute.mock_calls[0].kwargs["variable_values"],
             {"token": "some-token", "base": "some/strand", "proposed": json_schema_encoded, "allowBeta": True},
         )
+
+    def test_suggesting_sem_ver_initial(self):
+        """Test suggesting a version for a strand with no existing versions."""
+        mock_response = {"suggestSemVerViaToken": {"suggestedVersion": "0.1.0", "change": "INITIAL", "latestVersion": None, "stableVersion": None}}
+        json_schema_encoded = json.dumps({"some": "schema"})
+
+        with patch("gql.Client.execute", return_value=mock_response):
+            response = _suggest_sem_ver(
+                token="some-token",
+                base="some/strand",
+                proposed=json_schema_encoded,
+                allow_beta=True,
+            )
+
+        self.assertEqual(response, ("0.1.0", True, "initial", "", ""))
 
 
 class TestCreateStrandVersion(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ class TestCLI(unittest.TestCase):
         with patch("builtins.open", mock_open(read_data='{"some": "schema"}')):
             with patch(
                 "publish_strand_version.cli.publish_strand_version",
-                return_value=(None, None, None, "1.0.0", False),
+                return_value=(None, None, None, "1.0.0", False, "equal", "1.0.0", "1.0.0"),
             ):
                 with patch.dict(os.environ, {"GITHUB_OUTPUT": "/dev/null"}):
                     with patch("sys.stdout") as mock_stdout:
@@ -66,7 +66,7 @@ class TestCLI(unittest.TestCase):
 
         mock_publish_strand_version = patch(
             "publish_strand_version.cli.publish_strand_version",
-            return_value=(strand_url, strand_version_url, strand_version_uuid, "1.0.0-rc.1", True),
+            return_value=(strand_url, strand_version_url, strand_version_uuid, "1.0.0-rc.1", True, "major", "0.2.0", "0.2.0"),
         )
 
         with patch("builtins.open", mock_open(read_data='{"some": "schema"}')):
@@ -112,7 +112,7 @@ class TestCLI(unittest.TestCase):
 
         mock_publish_strand_version = patch(
             "publish_strand_version.cli.publish_strand_version",
-            return_value=(strand_url, strand_version_url, strand_version_uuid, "1.0.0-rc.1", False),
+            return_value=(strand_url, strand_version_url, strand_version_uuid, "1.0.0-rc.1", False, "major", "0.2.0", "0.2.0"),
         )
 
         with patch("builtins.open", mock_open(read_data='{"some": "schema"}')):


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#11](https://github.com/octue/publish-strand-version/pull/11))

### New features
- Add better outputs to suggested strand version

<!--- END AUTOGENERATED NOTES --->