### PR TITLE
OPS: Fix typo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,8 @@ jobs:
         tags: octue/publish-strand-version:${{ needs.tests.outputs.package_version }},octue/publish-strand-version:latest
 
     - name: Point action.yaml at pre-built image
-      run: sed -i "s|image: 'Dockerfile'|image: 'docker://octue/publish-strand-version:${{ needs.tests.outputs.package_version }}'|" action.yaml
+      run: |
+        sed -i "s|image: 'Dockerfile'|image: 'docker://octue/publish-strand-version:${{ needs.tests.outputs.package_version }}'|" action.yaml
 
     - name: Commit and tag release
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Version bumps
 
 When bumping the version, review README.md and other documentation/examples for hardcoded version references (e.g. in `uses:` lines or Docker image tags) and update them to match the new version.
+
+## GitHub workflows
+
+When editing GitHub workflow files (`.github/workflows/*.yml`), always lint against the GitHub Workflows YAML schema to catch syntax errors before committing.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
         run: echo "release_notes=$(cat tests/schema/notes.md)" >> $GITHUB_OUTPUT
 
       - name: Publish strand version
-        uses: octue/publish-strand-version@1.0.0
+        uses: octue/publish-strand-version@1.0.1
         with:
           token: ${{ secrets.STRANDS_TOKEN }}
           account: your-account-handle
@@ -107,7 +107,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Publish strand version
-        uses: octue/publish-strand-version@1.0.0
+        uses: octue/publish-strand-version@1.0.1
         with:
           token: ${{ secrets.STRANDS_TOKEN }}
           account: your-account-handle
@@ -135,7 +135,7 @@ jobs:
 
       - name: Suggest semantic version
         id: version
-        uses: octue/publish-strand-version@1.0.0
+        uses: octue/publish-strand-version@1.0.1
         with:
           token: ${{ secrets.STRANDS_TOKEN }}
           account: your-account-handle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "publish-strand-version"
-version = "1.0.0"
+version = "1.0.1"
 description = "A GitHub action that publishes JSON schemas to the Octue Strands app."
 authors = ["Marcus Lugg <marcus@octue.com>", "Tom Clark <tom@octue.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "publish-strand-version"
-version = "1.0.1"
+version = "1.0.0"
 description = "A GitHub action that publishes JSON schemas to the Octue Strands app."
 authors = ["Marcus Lugg <marcus@octue.com>", "Tom Clark <tom@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#13](https://github.com/octue/publish-strand-version/pull/13))

### Fixes
- FFS

### Operations
- Fix type in release workflow

### Other
- Update references

### Uncategorised!
- Merge branch 'main' into fix-suggest-outputs

<!--- END AUTOGENERATED NOTES --->